### PR TITLE
Generic implementation of DCTnum

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -2,34 +2,18 @@ use rustfft::FFTnum;
 use rustfft::num_traits::FloatConst;
 
 
-/// Generic floating point number, implemented for f32 and f64
+/// Generic floating point number
 pub trait DCTnum: FFTnum + FloatConst {
 	fn half() -> Self;
 	fn two() -> Self;
 }
-// impl DCTnum for f32 {
-// 	fn half() -> Self {
-// 		0.5
-// 	}
-// 	fn two() -> Self {
-// 		2.0
-// 	}
-// }
-// impl DCTnum for f64 {
-// 	fn half() -> Self {
-// 		0.5
-// 	}
-// 	fn two() -> Self {
-// 		2.0
-// 	}
-// }
 
 impl<T: FFTnum + FloatConst> DCTnum for T {
-	fn two() -> Self {
-		Self::from_f64(2.0).unwrap()
-	}
 	fn half() -> Self {
 		Self::from_f64(0.5).unwrap()
+	}
+	fn two() -> Self {
+		Self::from_f64(2.0).unwrap()
 	}
 }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,27 +1,35 @@
-use std::fmt::Debug;
 use rustfft::FFTnum;
 use rustfft::num_traits::FloatConst;
 
 
 /// Generic floating point number, implemented for f32 and f64
-pub trait DCTnum: FFTnum + FloatConst + Debug {
+pub trait DCTnum: FFTnum + FloatConst {
 	fn half() -> Self;
 	fn two() -> Self;
 }
-impl DCTnum for f32 {
-	fn half() -> Self {
-		0.5
-	}
+// impl DCTnum for f32 {
+// 	fn half() -> Self {
+// 		0.5
+// 	}
+// 	fn two() -> Self {
+// 		2.0
+// 	}
+// }
+// impl DCTnum for f64 {
+// 	fn half() -> Self {
+// 		0.5
+// 	}
+// 	fn two() -> Self {
+// 		2.0
+// 	}
+// }
+
+impl<T: FFTnum + FloatConst> DCTnum for T {
 	fn two() -> Self {
-		2.0
+		Self::from_f64(2.0).unwrap()
 	}
-}
-impl DCTnum for f64 {
 	fn half() -> Self {
-		0.5
-	}
-	fn two() -> Self {
-		2.0
+		Self::from_f64(0.5).unwrap()
 	}
 }
 


### PR DESCRIPTION
Similar to FFTnum, DCTnum is implemented generically for all types that implement FFTnum and FloatConst.