### PR TITLE
Update rustfft dependency to version 6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["algorithms", "compression", "multimedia::encoding", "science"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-rustfft = "5"
+rustfft = "6.0.1"
 
 [dev-dependencies]
 rand = "~0.4"

--- a/src/algorithm/type2and3_convert_to_fft.rs
+++ b/src/algorithm/type2and3_convert_to_fft.rs
@@ -81,9 +81,11 @@ impl<T: DctNum> Dct2<T> for Type2And3ConvertToFft<T> {
         }
 
         // the second half is the odd elements, in reverse order
-        let odd_end = buffer.len() - 1 - buffer.len() % 2;
-        for i in 0..buffer.len() / 2 {
-            fft_buffer[even_end + i] = Complex::from(buffer[odd_end - 2 * i]);
+        if self.len() > 1 {
+            let odd_end = self.len() - 1 - self.len() % 2;
+            for i in 0..self.len() / 2 {
+                fft_buffer[even_end + i] = Complex::from(buffer[odd_end - 2 * i]);
+            }
         }
 
         // run the fft
@@ -116,9 +118,11 @@ impl<T: DctNum> Dst2<T> for Type2And3ConvertToFft<T> {
         }
 
         // the second half is the odd elements, in reverse order and negated
-        let odd_end = buffer.len() - 1 - buffer.len() % 2;
-        for i in 0..buffer.len() / 2 {
-            fft_buffer[even_end + i] = Complex::from(-buffer[odd_end - 2 * i]);
+        if self.len() > 1 {
+            let odd_end = self.len() - 1 - self.len() % 2;
+            for i in 0..self.len() / 2 {
+                fft_buffer[even_end + i] = Complex::from(-buffer[odd_end - 2 * i]);
+            }
         }
 
         // run the fft
@@ -170,9 +174,11 @@ impl<T: DctNum> Dct3<T> for Type2And3ConvertToFft<T> {
         }
 
         // copy the second half of the fft buffer into the odd elements, reversed
-        let odd_end = buffer.len() - 1 - buffer.len() % 2;
-        for i in 0..buffer.len() / 2 {
-            buffer[odd_end - 2 * i] = fft_buffer[i + even_end].re;
+        if self.len() > 1 {
+            let odd_end = self.len() - 1 - self.len() % 2;
+            for i in 0..self.len() / 2 {
+                buffer[odd_end - 2 * i] = fft_buffer[i + even_end].re;
+            }
         }
     }
 }
@@ -212,9 +218,11 @@ impl<T: DctNum> Dst3<T> for Type2And3ConvertToFft<T> {
         }
 
         // copy the second half of the fft output into the odd elements, reversed
-        let odd_end = self.len() - 1 - self.len() % 2;
-        for i in 0..self.len() / 2 {
-            buffer[odd_end - 2 * i] = -fft_buffer[i + even_end].re;
+        if self.len() > 1 {
+            let odd_end = self.len() - 1 - self.len() % 2;
+            for i in 0..self.len() / 2 {
+                buffer[odd_end - 2 * i] = -fft_buffer[i + even_end].re;
+            }
         }
     }
 }


### PR DESCRIPTION
This PR intends to update rust_dct to use the latest version (6) of rust_fft.

This is the minimum viable PR that is compiling and passing the tests for me. But since this is a breaking change there are few other changes that you might want to include here? The two I can imagine are:

1. Update the `rand` dev dependency from 0.4 to 0.8
2. Adding an equivalent to the `process_outofplace_with_scratch`

(1) isn't that important I guess.
(2) could also be done later as a minor release if managed to be done as only adding new functions, otherwise might need another breaking change if changing some of the functions names.